### PR TITLE
feature-2 플랜리스트를 muuri로 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 ### poke what you think
 
 ## 변수명
-- 체크리스트 : check-list / todo-list / **plan** / entry / post / routine
+- 체크리스트 : check-list / todo-list / plan / entry / **post** / routine
 - 체크리스트 내 하나의 아이템 : **item** / todo / task / job / unit
 - 저장되어있는 아이템 : stock / **memory**

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
   "author": "jngcii",
   "license": "MIT",
   "dependencies": {
-    "muuri": "^0.9.5",
-    "muuri-react": "^3.1.6",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "^4.0.3",
+    "muuri": "0.8.0",
+    "muuri-react": "3.1.3",
+    "react": "16.13.1",
+    "react-dom": "16.13.1",
     "web-animations-js": "^2.3.2"
+  },
+  "devDependencies": {
+    "react-scripts": "1.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/Post/index.js
+++ b/src/components/Post/index.js
@@ -1,5 +1,3 @@
 import React from "react";
 
-export default React.memo(() => (
-    <></>
-))
+export default React.memo(() => <div></div>)

--- a/src/components/PostList/index.js
+++ b/src/components/PostList/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import {MuuriComponent} from "muuri-react";
 import {useContextState} from "../../utils/MainContextProvider";
 import "./style.css";
 
@@ -6,16 +7,38 @@ export default React.memo(() => {
     const {plans} = useContextState();
 
     return (
-        <>
+        <MuuriComponent {...girdProps}>
             {plans.map(plan => <PostListItem key={plan.id} title={plan.title}/>)}
-        </>
+        </MuuriComponent>
     );
 })
 
 const PostListItem = React.memo(({title}) => {
     return (
         <div className="post-list-item-outer">
-            <strong>{title}</strong>
+            <div className="post-list-item-inner">
+                <strong>{title}</strong>
+            </div>
         </div>
     );
 })
+
+const girdProps = {
+    dragEnabled: true,
+    dragFixed: true,
+    dragSortHeuristics: {
+        sortInterval: 0
+    },
+    dragContainer: document.body,
+    dragAxis: 'y',
+
+    // ClassNames
+    containerClass: "post-list-container",
+    itemClass: "post-list-item-outer",
+    itemVisibleClass: "post-list-item-outer-shown",
+    itemHiddenClass: "post-list-item-outer-hidden",
+    itemPositioningClass: "post-list-item-outer-positioning",
+    itemDraggingClass: "post-list-item-outer-dragging",
+    itemReleasingClass: "post-list-item-outer-releasing",
+    itemPlaceholderClass: "post-list-item-outer-placeholder"
+}

--- a/src/components/PostList/style.css
+++ b/src/components/PostList/style.css
@@ -1,6 +1,18 @@
+.post-list-container {
+    position: relative;
+    transition: height 0.4s;
+}
+
+/* 이 친구는 border 값이 들어가면 안됩니다 (used for positioning) */
 .post-list-item-outer {
+    position: absolute;
+    width: 100%;
+    margin: 5px 0;
+    background-color: #ccc;
+}
+
+/* 이 친구 이하에 스타일링 (used for animating the Item's visibility) */
+.post-list-item-inner {
     border: 5px solid #777;
-    margin: 5px auto;
-    padding: 0 5px;
-    cursor: pointer;
+    padding: 5px;
 }


### PR DESCRIPTION
플랜리스트를 muuri 컴퍼넌트를 통해 구현하고 drag & drop 적용
- **주의 : `react`를 `muuri`, `muuri-react`와 같이 사용하기 위해서는 `react` 버전이 17 미만이어야 합니다.** => 9dce772
- 체크리스트를 나타내는 변수명이 plan이 아니라 post로 사용되고 있어서 README에 업데이트했습니다. => a712ccc