### PR TITLE
feature-28 Item/Post 엔티티에 순서를 나타내는 필드(order) 추가 및 리팩터링

### DIFF
--- a/src/components/ButtonAddPost/index.tsx
+++ b/src/components/ButtonAddPost/index.tsx
@@ -12,7 +12,7 @@ export default React.memo(() => {
   const dispatch = useDispatch();
 
   const onAdd = () => {
-    const sortedKeyList = [...posts.map((it) => it.id)].sort(key8Factory.compare);
+    const sortedKeyList = [...posts.map((it) => it.order)].sort(key8Factory.compare);
 
     const newKey = sortedKeyList.length > 0
       ? key8Factory.first(sortedKeyList[0])

--- a/src/components/ItemGrid/index.jsx
+++ b/src/components/ItemGrid/index.jsx
@@ -13,7 +13,7 @@ export default React.memo(({ children }) => {
       const currentItems = !currentPost ? [] : items.filter((it) => it.postId === currentPost.id);
 
       return (currentItems.length > 1
-        ? currentItems.sort((before, after) => key8Factory.compare(before.id, after.id))
+        ? currentItems.sort((before, after) => key8Factory.compare(before.order, after.order))
         : currentItems
       );
     }, [items, currentPost],
@@ -23,7 +23,7 @@ export default React.memo(({ children }) => {
 
   const changeTargetKey = (item) => {
     const postItem = item.getData();
-    const key = postItem.id;
+    const key = postItem.order;
 
     const position = item.getPosition().top;
 
@@ -38,23 +38,23 @@ export default React.memo(({ children }) => {
     let before;
     let after;
 
-    const isBiggerThanTarget = key8Factory.compare(key, target.id) > 0;
+    const isBiggerThanTarget = key8Factory.compare(key, target.order) > 0;
 
     // 아래 있던 것이 위로
     if (isBiggerThanTarget) {
-      after = target.id;
-      if (changedIdx > 0) before = sortedItems[changedIdx - 1].id;
+      after = target.order;
+      if (changedIdx > 0) before = sortedItems[changedIdx - 1].order;
       // 위에 있던 것이 아래로
     } else {
-      before = target.id;
-      if (changedIdx < sortedItems.length - 1) after = sortedItems[changedIdx + 1].id;
+      before = target.order;
+      if (changedIdx < sortedItems.length - 1) after = sortedItems[changedIdx + 1].order;
     }
 
     const newKey = key8Factory.build(before, after);
 
-    const newItem = { ...postItem, id: newKey };
+    const newItem = { ...postItem, order: newKey };
     item.setData(newItem);
-    dispatch(updateItem({ id: key, item: newItem }));
+    dispatch(updateItem({ id: postItem.id, item: newItem }));
   };
 
   const recordCurrentPosition = (item) => {
@@ -67,7 +67,7 @@ export default React.memo(({ children }) => {
       onDragEnd={changeTargetKey}
       onDragStart={recordCurrentPosition}
       propsToData={({ item }) => item}
-      sort="id:asc"
+      sort="order:asc"
     >
       {children}
     </MuuriComponent>

--- a/src/components/ItemList/index.tsx
+++ b/src/components/ItemList/index.tsx
@@ -3,8 +3,11 @@ import { useDispatch } from 'react-redux';
 import { useDraggable } from 'muuri-react';
 import { checkItem } from '../../redux/slices/itemSlice';
 import { Item as ItemInterface } from '../../types/object';
-import ItemGrid from '../ItemGrid';
 import './style.scss';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import ItemGrid from '../ItemGrid';
 
 export default React.memo(({ items }: ItemsProps) => {
   const children = items.map((item) => <Item key={item.id} item={item} />);

--- a/src/components/PostGrid/index.jsx
+++ b/src/components/PostGrid/index.jsx
@@ -10,7 +10,7 @@ export default React.memo(({ children }) => {
 
   const sortedPosts = useMemo(
     () => (posts.length > 1
-      ? [...posts].sort((before, after) => key8Factory.compare(before.id, after.id))
+      ? [...posts].sort((before, after) => key8Factory.compare(before.order, after.order))
       : [...posts]),
     [posts],
   );
@@ -19,7 +19,7 @@ export default React.memo(({ children }) => {
 
   const changeTargetKey = (item) => {
     const post = item.getData();
-    const key = post.id;
+    const key = post.order;
 
     const position = item.getPosition().top;
 
@@ -34,23 +34,23 @@ export default React.memo(({ children }) => {
     let before;
     let after;
 
-    const isBiggerThanTarget = key8Factory.compare(key, target.id) > 0;
+    const isBiggerThanTarget = key8Factory.compare(key, target.order) > 0;
 
     // 아래 있던 것이 위로
     if (isBiggerThanTarget) {
-      after = target.id;
-      if (changedIdx > 0) before = sortedPosts[changedIdx - 1].id;
+      after = target.order;
+      if (changedIdx > 0) before = sortedPosts[changedIdx - 1].order;
     // 위에 있던 것이 아래로
     } else {
-      before = target.id;
-      if (changedIdx < sortedPosts.length - 1) after = sortedPosts[changedIdx + 1].id;
+      before = target.order;
+      if (changedIdx < sortedPosts.length - 1) after = sortedPosts[changedIdx + 1].order;
     }
 
     const newKey = key8Factory.build(before, after);
 
-    const newPost = { ...post, id: newKey };
+    const newPost = { ...post, order: newKey };
     item.setData(newPost);
-    dispatch(updatePost({ id: key, post: newPost }));
+    dispatch(updatePost({ id: post.id, post: newPost }));
   };
 
   const recordCurrentPosition = (item) => {
@@ -63,7 +63,7 @@ export default React.memo(({ children }) => {
       onDragEnd={changeTargetKey}
       onDragStart={recordCurrentPosition}
       propsToData={({ post }) => post}
-      sort="id:asc"
+      sort="order:asc"
     >
       {children}
     </MuuriComponent>

--- a/src/components/PostList/index.tsx
+++ b/src/components/PostList/index.tsx
@@ -40,7 +40,7 @@ const PostListItemTitle = React.memo(({ post }: PostProps) => {
 
   return (
     <div className="post-list-item-title" onClick={onClick}>
-      <strong>{post.id}</strong>
+      <strong>{post.order}</strong>
     </div>
   );
 });

--- a/src/redux/api/mockingRepository.ts
+++ b/src/redux/api/mockingRepository.ts
@@ -2,28 +2,28 @@ import { createItem, createPost } from '../utils/objectCreator';
 import { Item, Post } from '../../types/object';
 
 let posts = [
-  createPost('EEEEEEEE', 'third'),
-  createPost('IIIIIIII', 'fifth'),
-  createPost('CCCCCCCC', 'second'),
-  createPost('AAAAAAAA', 'first'),
-  createPost('GGGGGGGG', 'fourth'),
+  createPost('EEEEEEEE', 'third', '3'),
+  createPost('IIIIIIII', 'fifth', '5'),
+  createPost('CCCCCCCC', 'second', '2'),
+  createPost('AAAAAAAA', 'first', '1'),
+  createPost('GGGGGGGG', 'fourth', '4'),
 ];
 
 let items = [
-  createItem('B0000000', 'AAAAAAAA', 'first - 2', false),
-  createItem('A0000000', 'AAAAAAAA', 'first - 1', true),
-  createItem('C0000000', 'AAAAAAAA', 'first - 3', false),
+  createItem('B0000000', '1', 'first - 2', false),
+  createItem('A0000000', '1', 'first - 1', true),
+  createItem('C0000000', '1', 'first - 3', false),
 
-  createItem('E0000000', 'CCCCCCCC', 'second - 2', true),
-  createItem('G0000000', 'CCCCCCCC', 'second - 4', false),
-  createItem('F0000000', 'CCCCCCCC', 'second - 3', true),
-  createItem('D0000000', 'CCCCCCCC', 'second - 1', true),
+  createItem('E0000000', '2', 'second - 2', true),
+  createItem('G0000000', '2', 'second - 4', false),
+  createItem('F0000000', '2', 'second - 3', true),
+  createItem('D0000000', '2', 'second - 1', true),
 
-  createItem('L0000000', 'IIIIIIII', 'fifth - 5', false),
-  createItem('I0000000', 'IIIIIIII', 'fifth - 2', false),
-  createItem('H0000000', 'IIIIIIII', 'fifth - 1', false),
-  createItem('J0000000', 'IIIIIIII', 'fifth - 3', false),
-  createItem('K0000000', 'IIIIIIII', 'fifth - 4', false),
+  createItem('L0000000', '5', 'fifth - 5', false),
+  createItem('I0000000', '5', 'fifth - 2', false),
+  createItem('H0000000', '5', 'fifth - 1', false),
+  createItem('J0000000', '5', 'fifth - 3', false),
+  createItem('K0000000', '5', 'fifth - 4', false),
 ];
 
 const mockingRepository = {

--- a/src/redux/utils/objectCreator.ts
+++ b/src/redux/utils/objectCreator.ts
@@ -1,9 +1,12 @@
-import {Item, Post} from '../../types/object';
+import { nanoid } from '@reduxjs/toolkit';
+import { Item, Post } from '../../types/object';
 
-export function createPost(id: string, title: string): Post {
-  return { id, title };
+export function createPost(order: string, title: string, id?: string): Post {
+  return { id: !id ? nanoid() : id, order, title };
 }
 
-export function createItem(id: string, postId: string, content: string, isDone: boolean): Item {
-  return { id, postId, content, isDone };
+export function createItem(order: string, postId: string, content: string, isDone: boolean): Item {
+  return {
+    id: nanoid(), order, postId, content, isDone,
+  };
 }

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -1,2 +1,2 @@
-export interface Post {id: string, title: string}
-export interface Item {id: string, postId: string, content: string, isDone: boolean}
+export interface Post {id: string, order: string, title: string}
+export interface Item {id: string, order: string, postId: string, content: string, isDone: boolean}


### PR DESCRIPTION
# 무엇을
- Item/Post 엔티티에 순서를 나타내는 필드(order) 추가 및 리팩터링

# 왜
- Post의 순서를 나타내는 필드가 id일 경우 몇가지 문제가 드러남
  - Post의 순서를 바꾸었을 때, Post의 id는 바뀌는데 Item의 postId는 변하지 않아서 Item들이 주인을 잃게됩니다.
  - List를 렌더링할때 (`.map`사용) key값으로 id를 넘겨주는데, id가 바뀌면 muuri 모듈에서 dnd 메커니즘에 사용할 Item의 id를 찾지 못하는 문제가 발생합니다.
    <img width="427" alt="Screen Shot 2021-10-19 at 11 10 32 PM" src="https://user-images.githubusercontent.com/41500212/137927457-666c9f2f-cb78-4a53-9b0c-1f18e7e3116c.png">
  