### PR TITLE
feature-48 메모리 기능 구현 (3)

### DIFF
--- a/src/components/FormMemoryAdd/index.tsx
+++ b/src/components/FormMemoryAdd/index.tsx
@@ -1,0 +1,67 @@
+import React, { FormEvent, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import useInput from '../../hooks/InputHook';
+import { key8Factory } from '../../redux/utils/keyFactory';
+import { createMemory } from '../../redux/utils/objectCreator';
+import { addMemory } from '../../redux/slices/memorySlice';
+import { RootState } from '../../redux/store';
+import { Memory } from '../../types/object';
+import './style.scss';
+
+export default React.memo(({ parent }: FormMemoryAddTypes) => {
+  const { memory: { memories } } = useSelector((state: RootState) => state);
+  const dispatch = useDispatch();
+  const inputHooks = useInput('');
+
+  const filteredMemories = useMemo(() => [...memories].filter(
+    (it) => it.parentId === parent.id,
+  ), [memories, parent]);
+
+  const sortedMemories = useMemo(() => (filteredMemories.length > 1
+    ? filteredMemories.sort((before, after) => key8Factory.compare(before.order, after.order))
+    : filteredMemories),
+  [filteredMemories]);
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (inputHooks.value.trim() !== '') {
+      const order = sortedMemories.length === 0
+        ? key8Factory.build()
+        : key8Factory.build(sortedMemories[sortedMemories.length - 1].order);
+      const newMemory = createMemory(
+        order,
+        inputHooks.value,
+        true,
+        parent.id,
+        parent.level + 1,
+      );
+      dispatch(addMemory(newMemory));
+    }
+    inputHooks.setValue('');
+  };
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="component-form-memory-add"
+    >
+      <input
+        value={inputHooks.value}
+        onChange={inputHooks.onChangeValue}
+        placeholder="Please enter..."
+        className="component-form-memory-add-input"
+      />
+      <button
+        type="submit"
+        className="component-form-memory-add-submit"
+      >
+        ADD
+      </button>
+    </form>
+  );
+});
+
+type FormMemoryAddTypes = {
+  parent: Memory,
+};

--- a/src/components/FormMemoryAdd/style.scss
+++ b/src/components/FormMemoryAdd/style.scss
@@ -1,0 +1,12 @@
+.component-form-memory-add {
+    display: flex;
+    margin: 20px auto 5px;
+}
+
+.component-form-memory-add-input {
+    flex: 1;
+}
+
+.component-form-memory-add-submit {
+    padding: 5px;
+}

--- a/src/components/ItemList/index.tsx
+++ b/src/components/ItemList/index.tsx
@@ -12,8 +12,7 @@ import { RootState } from '../../redux/store';
 import { key8Factory } from '../../redux/utils/keyFactory';
 import { createInitialItem, createItem } from '../../redux/utils/objectCreator';
 import useInput, { InputHook } from '../../hooks/InputHook';
-import { setFocusedItem, setSelectableAsync } from '../../redux/slices/memorySlice';
-import { toggleMemory } from '../../redux/slices/defaultSlice';
+import { setFocusedItem } from '../../redux/slices/memorySlice';
 import './style.scss';
 
 export default React.memo(({ post, items }: ItemsProps) => {
@@ -131,7 +130,6 @@ const ItemContent = React.memo(({ item, inputHook }: ItemContentProps) => {
   // Blur 당시 Item이 빈문자가 아닐 때에만 Item Update Dispatch
   const onBlur = useCallback(() => {
     dispatch(setFocusedItem(undefined));
-    dispatch(setSelectableAsync(false));
     if (!value || !value.trim()) {
       dispatch(removeItem(item.id));
     } else {
@@ -141,9 +139,7 @@ const ItemContent = React.memo(({ item, inputHook }: ItemContentProps) => {
   }, [item, value]);
 
   const onFocus = () => {
-    dispatch(toggleMemory(true));
     dispatch(setFocusedItem(item));
-    dispatch(setSelectableAsync(true));
   };
 
   return (

--- a/src/components/ItemList/index.tsx
+++ b/src/components/ItemList/index.tsx
@@ -10,9 +10,9 @@ import { Item as ItemInterface, Post } from '../../types/object';
 import ItemGrid from '../ItemGrid';
 import { RootState } from '../../redux/store';
 import { key8Factory } from '../../redux/utils/keyFactory';
-import { createInitialItem, createItem } from '../../redux/utils/objectCreator';
+import { createInitialItem, createItem, createSpareMemory } from '../../redux/utils/objectCreator';
 import useInput, { InputHook } from '../../hooks/InputHook';
-import { setFocusedItem } from '../../redux/slices/memorySlice';
+import { addMemoryThunk, setFocusedItem } from '../../redux/slices/memorySlice';
 import './style.scss';
 
 export default React.memo(({ post, items }: ItemsProps) => {
@@ -88,10 +88,7 @@ export const ItemCheckbox = React.memo(({ item, onCheck }: ItemCheckboxProps) =>
 
 const ItemContent = React.memo(({ item, inputHook }: ItemContentProps) => {
   const { value, ref, onChangeValue } = inputHook;
-  const {
-    item: { items },
-    memory: { selectable },
-  } = useSelector((state: RootState) => state);
+  const { item: { items } } = useSelector((state: RootState) => state);
   const dispatch = useDispatch();
 
   // 리렌더링 될 때 text가 비어있다 : 새로 생긴 ItemContent 컴퍼넌트다
@@ -135,6 +132,12 @@ const ItemContent = React.memo(({ item, inputHook }: ItemContentProps) => {
     } else {
       const newItem = { ...item, content: value };
       dispatch(updateItem({ id: item.id, item: newItem }));
+
+      // 완전 새로 작성한 item일 경우에만 Memory에 추가
+      if (item.content.trim() === '') {
+        const newMemory = createSpareMemory(value);
+        dispatch(addMemoryThunk(newMemory));
+      }
     }
   }, [item, value]);
 

--- a/src/components/MemoryChildGrid/index.jsx
+++ b/src/components/MemoryChildGrid/index.jsx
@@ -1,0 +1,64 @@
+import React, { useMemo, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { MuuriComponent } from 'muuri-react';
+import { key8Factory } from '../../redux/utils/keyFactory';
+import gridItemReplacer from '../../redux/utils/gridItemReplacer';
+import { updateMemory } from '../../redux/slices/memorySlice';
+
+export default React.memo(({ children, parent }) => {
+  const { memories } = useSelector((state) => state.memory);
+  const dispatch = useDispatch();
+
+  const sortedMemories = useMemo(
+    () => (memories.length > 1
+      ? [...memories].filter(
+        (it) => it.parentId === parent.id && it.fixed,
+      ).sort(
+        (before, after) => key8Factory.compare(before.order, after.order),
+      ) : [...memories].filter((it) => it.parentId === parent.id && it.fixed)),
+    [memories],
+  );
+
+  const currentPosition = useRef(0);
+
+  const changeTargetKey = (item) => {
+    const replacedMemory = gridItemReplacer.replace(item, currentPosition, sortedMemories);
+    if (!replacedMemory) return;
+    item.setData(replacedMemory);
+    dispatch(updateMemory({ id: replacedMemory.id, memory: replacedMemory }));
+  };
+
+  const recordCurrentPosition = (item) => {
+    currentPosition.current = item.getPosition().top;
+  };
+
+  return (
+    <MuuriComponent
+      {...gridProps}
+      onDragEnd={changeTargetKey}
+      onDragStart={recordCurrentPosition}
+      propsToData={({ memory }) => memory}
+    >
+      {children}
+    </MuuriComponent>
+  );
+});
+
+const gridProps = {
+  dragEnabled: true,
+  dragFixed: true,
+  dragSortHeuristics: {
+    sortInterval: 0,
+  },
+  dragAxis: 'y',
+
+  // ClassNames
+  containerClass: 'component-memory-child-list-container',
+  itemClass: 'component-memory-child-item-outer',
+  itemVisibleClass: 'component-memory-child-item-outer-shown',
+  itemHiddenClass: 'component-memory-child-item-outer-hidden',
+  itemPositioningClass: 'component-memory-child-item-outer-positioning',
+  itemDraggingClass: 'component-memory-child-item-outer-dragging',
+  itemReleasingClass: 'component-memory-child-item-outer-releasing',
+  itemPlaceholderClass: 'component-memory-child-item-outer-placeholder',
+};

--- a/src/components/MemoryChildList/index.tsx
+++ b/src/components/MemoryChildList/index.tsx
@@ -17,11 +17,13 @@ export default React.memo(({ parent, editing, visible }: MemoryChildListPropType
     .filter((it) => it.parentId === parent.id)
     .map((it) => <MemoryChildItem key={it.id} memory={it} editing={editing} />);
 
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const grid = <MemoryChildGrid parent={parent}>{children}</MemoryChildGrid>;
+
   return visible ? (
     <div className="component-memory-child-list-container">
-      <MemoryChildGrid parent={parent}>
-        {children}
-      </MemoryChildGrid>
+      {grid}
 
       <FormMemoryAdd parent={parent} />
     </div>

--- a/src/components/MemoryChildList/index.tsx
+++ b/src/components/MemoryChildList/index.tsx
@@ -6,6 +6,7 @@ import './style.scss';
 import { createInitialItemByMemory, createItemByMemory } from '../../redux/utils/objectCreator';
 import { key8Factory } from '../../redux/utils/keyFactory';
 import { addItem } from '../../redux/slices/itemSlice';
+import FormMemoryAdd from '../FormMemoryAdd';
 
 export default React.memo(({ parent, editing, visible }: MemoryChildListPropTypes) => {
   const { memories } = useSelector((state: RootState) => state.memory);
@@ -17,6 +18,8 @@ export default React.memo(({ parent, editing, visible }: MemoryChildListPropType
   return (
     <div className={`component-memory-child-list-wrapper ${!visible && 'invisible-display'}`}>
       {children}
+
+      <FormMemoryAdd parent={parent} />
     </div>
   );
 });

--- a/src/components/MemoryChildList/index.tsx
+++ b/src/components/MemoryChildList/index.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from '../../redux/store';
 import { Memory } from '../../types/object';
 import './style.scss';
+import { createInitialItemByMemory, createItemByMemory } from '../../redux/utils/objectCreator';
+import { key8Factory } from '../../redux/utils/keyFactory';
+import { addItem } from '../../redux/slices/itemSlice';
 
 export default React.memo(({ parent, editing, visible }: MemoryChildListPropTypes) => {
   const { memories } = useSelector((state: RootState) => state.memory);
@@ -19,12 +22,39 @@ export default React.memo(({ parent, editing, visible }: MemoryChildListPropType
 });
 
 const MemoryChildItem = React.memo(({ child }: MemoryChildItemPropTypes) => {
-  const { selectable } = useSelector((state: RootState) => state.memory);
+  const {
+    post: { currentPost },
+    item: { items },
+    memory: { memories, selectable },
+  } = useSelector((state: RootState) => state);
+  const dispatch = useDispatch();
+
+  const onSelect = () => {
+    const filteredItems = items.filter((it) => it.postId === currentPost.id);
+
+    const parent = memories.find((it) => it.id === child.parentId);
+    const prefix = !parent ? '' : `${parent.content} > `;
+
+    let newItem;
+
+    if (filteredItems.length === 0) {
+      newItem = createInitialItemByMemory(currentPost.id, `${prefix}${child.content}`, child);
+    } else {
+      const sortedItems = filteredItems.length === 1
+        ? filteredItems
+        : filteredItems.sort((before, after) => key8Factory.compare(before.order, after.order));
+      const lastItem = sortedItems[sortedItems.length - 1];
+      const newOrder = key8Factory.build(lastItem.order, undefined);
+      newItem = createItemByMemory(newOrder, currentPost.id, `${prefix}${child.content}`, child);
+    }
+
+    dispatch(addItem(newItem));
+  };
 
   return (
     <div className="component-memory-child-item-wrapper">
       <div className={`component-memory-child-item-select ${selectable ? 'selectable' : 'non-selectable'}`}>
-        <div className="component-memory-child-item-select-button" onClick={() => console.log('')} />
+        <div className="component-memory-child-item-select-button" onClick={onSelect} />
       </div>
       {child.content}
     </div>

--- a/src/components/MemoryChildList/index.tsx
+++ b/src/components/MemoryChildList/index.tsx
@@ -75,7 +75,7 @@ const MemoryChildItem = React.memo(({ memory, editing }: MemoryProps) => {
 
       <div className="component-memory-child-item">
         <MemoryChildContent memory={memory} editing={editing} />
-        <MemoryChildDragger editing={editing} toggleDraggable={toggleDraggable} />
+        <MemoryChildDragger toggleDraggable={toggleDraggable} />
       </div>
     </div>
   );
@@ -87,13 +87,13 @@ const MemoryChildContent = React.memo(({ memory, editing }: MemoryProps) => (
   </div>
 ));
 
-const MemoryChildDragger = React.memo(({ editing, toggleDraggable }: DraggerProps) => {
+const MemoryChildDragger = React.memo(({ toggleDraggable }: DraggerProps) => {
   const enableDrag = () => toggleDraggable(true);
   const disableDrag = () => toggleDraggable(false);
 
   return (
     <div
-      className={`component-memory-child-item-dragger ${!editing && 'invisible-display'}`}
+      className="component-memory-child-item-dragger"
       onMouseOver={enableDrag}
       onMouseLeave={disableDrag}
     />
@@ -102,4 +102,4 @@ const MemoryChildDragger = React.memo(({ editing, toggleDraggable }: DraggerProp
 
 type MemoryChildListPropTypes = { parent: Memory, editing: boolean, visible: boolean };
 type MemoryProps = { memory: Memory, editing: boolean };
-type DraggerProps = { editing: boolean, toggleDraggable: (drag: boolean) => void };
+type DraggerProps = { toggleDraggable: (drag: boolean) => void };

--- a/src/components/MemoryChildList/index.tsx
+++ b/src/components/MemoryChildList/index.tsx
@@ -1,30 +1,34 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { useDraggable } from 'muuri-react';
 import { RootState } from '../../redux/store';
 import { Memory } from '../../types/object';
-import './style.scss';
 import { createInitialItemByMemory, createItemByMemory } from '../../redux/utils/objectCreator';
 import { key8Factory } from '../../redux/utils/keyFactory';
 import { addItem } from '../../redux/slices/itemSlice';
 import FormMemoryAdd from '../FormMemoryAdd';
+import MemoryChildGrid from '../MemoryChildGrid';
+import './style.scss';
 
 export default React.memo(({ parent, editing, visible }: MemoryChildListPropTypes) => {
   const { memories } = useSelector((state: RootState) => state.memory);
 
   const children = memories
     .filter((it) => it.parentId === parent.id)
-    .map((it) => <MemoryChildItem key={it.id} child={it} />);
+    .map((it) => <MemoryChildItem key={it.id} memory={it} editing={editing} />);
 
-  return (
-    <div className={`component-memory-child-list-wrapper ${!visible && 'invisible-display'}`}>
-      {children}
+  return visible ? (
+    <div className="component-memory-child-list-container">
+      <MemoryChildGrid parent={parent}>
+        {children}
+      </MemoryChildGrid>
 
       <FormMemoryAdd parent={parent} />
     </div>
-  );
+  ) : <div />;
 });
 
-const MemoryChildItem = React.memo(({ child }: MemoryChildItemPropTypes) => {
+const MemoryChildItem = React.memo(({ memory, editing }: MemoryProps) => {
   const {
     post: { currentPost },
     item: { items },
@@ -35,40 +39,65 @@ const MemoryChildItem = React.memo(({ child }: MemoryChildItemPropTypes) => {
   const onSelect = () => {
     const filteredItems = items.filter((it) => it.postId === currentPost.id);
 
-    const parent = memories.find((it) => it.id === child.parentId);
+    const parent = memories.find((it) => it.id === memory.parentId);
     const prefix = !parent ? '' : `${parent.content} > `;
 
     let newItem;
 
     if (filteredItems.length === 0) {
-      newItem = createInitialItemByMemory(currentPost.id, `${prefix}${child.content}`, child);
+      newItem = createInitialItemByMemory(currentPost.id, `${prefix}${memory.content}`, memory);
     } else {
       const sortedItems = filteredItems.length === 1
         ? filteredItems
         : filteredItems.sort((before, after) => key8Factory.compare(before.order, after.order));
       const lastItem = sortedItems[sortedItems.length - 1];
       const newOrder = key8Factory.build(lastItem.order, undefined);
-      newItem = createItemByMemory(newOrder, currentPost.id, `${prefix}${child.content}`, child);
+      newItem = createItemByMemory(newOrder, currentPost.id, `${prefix}${memory.content}`, memory);
     }
 
     dispatch(addItem(newItem));
   };
 
+  const draggable = useDraggable();
+
+  useEffect(() => {
+    draggable(false);
+  }, []);
+  const toggleDraggable = (drag: boolean) => draggable(drag);
+
   return (
-    <div className="component-memory-child-item-wrapper">
+    <div className="component-memory-child-item-inner">
       <div className={`component-memory-child-item-select ${selectable ? 'selectable' : 'non-selectable'}`}>
         <div className="component-memory-child-item-select-button" onClick={onSelect} />
       </div>
-      {child.content}
+
+      <div className="component-memory-child-item">
+        <MemoryChildContent memory={memory} editing={editing} />
+        <MemoryChildDragger editing={editing} toggleDraggable={toggleDraggable} />
+      </div>
     </div>
   );
 });
 
-type MemoryChildListPropTypes = {
-  parent: Memory,
-  editing: boolean,
-  visible: boolean
-};
-type MemoryChildItemPropTypes = {
-  child: Memory,
-};
+const MemoryChildContent = React.memo(({ memory, editing }: MemoryProps) => (
+  <div className="component-memory-child-item-content">
+    <strong>{memory.content}</strong>
+  </div>
+));
+
+const MemoryChildDragger = React.memo(({ editing, toggleDraggable }: DraggerProps) => {
+  const enableDrag = () => toggleDraggable(true);
+  const disableDrag = () => toggleDraggable(false);
+
+  return (
+    <div
+      className={`component-memory-child-item-dragger ${!editing && 'invisible-display'}`}
+      onMouseOver={enableDrag}
+      onMouseLeave={disableDrag}
+    />
+  );
+});
+
+type MemoryChildListPropTypes = { parent: Memory, editing: boolean, visible: boolean };
+type MemoryProps = { memory: Memory, editing: boolean };
+type DraggerProps = { editing: boolean, toggleDraggable: (drag: boolean) => void };

--- a/src/components/MemoryChildList/style.scss
+++ b/src/components/MemoryChildList/style.scss
@@ -5,14 +5,32 @@
     transition: 2s;
 }
 
-.component-memory-child-item-wrapper {
-    padding: 5px;
-    border: 5px solid #000;
-    background-color: #fff;
-    margin: 5px auto;
+.component-memory-child-item-outer-dragging {
+    z-index: 9999;
+}
+
+.component-memory-child-item-inner {
+    width: 100%;
+}
+
+.component-memory-child-item {
     display: flex;
     align-items: center;
+    margin: 5px;
+    padding: 5px;
     height: 25px;
+    border: 5px solid #000;
+    background-color: #fff;
+}
+
+.component-memory-child-item-content {
+    flex: 1;
+}
+
+.component-memory-child-item-dragger {
+    width: 20px;
+    height: 20px;
+    background-color: #000;
 }
 
 .component-memory-child-item-select {

--- a/src/components/MemoryChildList/style.scss
+++ b/src/components/MemoryChildList/style.scss
@@ -8,6 +8,7 @@
 .component-memory-child-item-wrapper {
     padding: 5px;
     border: 5px solid #000;
+    background-color: #fff;
     margin: 5px auto;
     display: flex;
     align-items: center;

--- a/src/components/MemoryChildList/style.scss
+++ b/src/components/MemoryChildList/style.scss
@@ -1,7 +1,7 @@
 .component-memory-child-list-wrapper {
     border: 5px solid #000;
     border-top: 0;
-    padding: 5px 5px 50px;
+    padding: 0 5px;
     transition: 2s;
 }
 
@@ -11,6 +11,7 @@
     margin: 5px auto;
     display: flex;
     align-items: center;
+    height: 25px;
 }
 
 .component-memory-child-item-select {

--- a/src/components/MemoryChildList/style.scss
+++ b/src/components/MemoryChildList/style.scss
@@ -5,6 +5,10 @@
     transition: 2s;
 }
 
+.component-memory-child-list-container {
+    overflow: hidden;
+}
+
 .component-memory-child-item-outer-dragging {
     z-index: 9999;
 }

--- a/src/components/MemoryParentGrid/index.jsx
+++ b/src/components/MemoryParentGrid/index.jsx
@@ -11,8 +11,11 @@ export default React.memo(({ children }) => {
 
   const sortedMemories = useMemo(
     () => (memories.length > 1
-      ? [...memories].sort((before, after) => key8Factory.compare(before.order, after.order))
-      : [...memories]),
+      ? [...memories].filter(
+        (it) => it.parentId === '0' && it.fixed,
+      ).sort(
+        (before, after) => key8Factory.compare(before.order, after.order),
+      ) : [...memories].filter((it) => it.parentId === '0' && it.fixed)),
     [memories],
   );
 

--- a/src/components/MemoryParentList/index.tsx
+++ b/src/components/MemoryParentList/index.tsx
@@ -25,7 +25,7 @@ export default React.memo(({ editing }: EditingProps) => {
   } = useSelector((state: RootState) => state);
 
   useEffect(() => {
-    setCurrentMemories(memories.filter((it) => it.parentId === '0'));
+    setCurrentMemories(memories.filter((it) => it.parentId === '0' && it.fixed));
   }, [memories]);
 
   const children = useMemo(() => currentMemories.map((memory) => (
@@ -33,9 +33,11 @@ export default React.memo(({ editing }: EditingProps) => {
   )), [currentMemories, editing]);
 
   return currentMemories.length > 0 ? (
-    <MemoryParentGrid>
-      {children}
-    </MemoryParentGrid>
+    <div>
+      <MemoryParentGrid>
+        {children}
+      </MemoryParentGrid>
+    </div>
   ) : <MemoryParentEmpty />;
 });
 

--- a/src/components/MemoryParentList/index.tsx
+++ b/src/components/MemoryParentList/index.tsx
@@ -15,6 +15,8 @@ import {
   createInitialItemByMemory,
   createItemByMemory,
 } from '../../redux/utils/objectCreator';
+import FormMemoryAdd from '../FormMemoryAdd';
+import { rootMemory } from '../../redux/api/mockingRepository';
 import './style.scss';
 
 export default React.memo(({ editing }: EditingProps) => {
@@ -37,6 +39,8 @@ export default React.memo(({ editing }: EditingProps) => {
       <MemoryParentGrid>
         {children}
       </MemoryParentGrid>
+
+      <FormMemoryAdd parent={rootMemory} />
     </div>
   ) : <MemoryParentEmpty />;
 });
@@ -76,7 +80,7 @@ const MemoryParentItem = React.memo(({ memory, editing }: MemoryProps) => {
     } else {
       setHeight(undefined);
     }
-  }, [childrenVisible]);
+  }, [childrenVisible, childrenContainerHeight]);
 
   const onSelect = () => {
     const filteredItems = items.filter((it) => it.postId === currentPost.id);

--- a/src/components/MemoryParentList/index.tsx
+++ b/src/components/MemoryParentList/index.tsx
@@ -133,7 +133,7 @@ const MemoryParentItem = React.memo(({ memory, editing }: MemoryProps) => {
           >
             TOGGLE
           </button>
-          <MemoryParentDragger editing={editing} toggleDraggable={toggleDraggable} />
+          <MemoryParentDragger toggleDraggable={toggleDraggable} />
         </div>
       </div>
       <MemoryChildList
@@ -151,13 +151,13 @@ const MemoryParentContent = React.memo(({ memory, editing }: MemoryProps) => (
   </div>
 ));
 
-const MemoryParentDragger = React.memo(({ editing, toggleDraggable }: DraggerProps) => {
+const MemoryParentDragger = React.memo(({ toggleDraggable }: DraggerProps) => {
   const enableDrag = () => toggleDraggable(true);
   const disableDrag = () => toggleDraggable(false);
 
   return (
     <div
-      className={`component-memory-parent-item-dragger ${!editing && 'invisible-display'}`}
+      className="component-memory-parent-item-dragger"
       onMouseOver={enableDrag}
       onMouseLeave={disableDrag}
     />
@@ -166,4 +166,4 @@ const MemoryParentDragger = React.memo(({ editing, toggleDraggable }: DraggerPro
 
 type EditingProps = { editing: boolean };
 type MemoryProps = { memory: Memory, editing: boolean };
-type DraggerProps = { editing: boolean, toggleDraggable: (drag: boolean) => void };
+type DraggerProps = { toggleDraggable: (drag: boolean) => void };

--- a/src/components/MemoryParentList/index.tsx
+++ b/src/components/MemoryParentList/index.tsx
@@ -67,10 +67,6 @@ const MemoryParentItem = React.memo(({ memory, editing }: MemoryProps) => {
     }
   }, [childrenVisible]);
 
-  useEffect(() => {
-    if (selectable) setChildrenVisible(true);
-  }, [selectable]);
-
   const onSelect = () => {
     console.log('todo : 메모리에서 선택했을 때 적용');
   };

--- a/src/components/MemoryParentList/index.tsx
+++ b/src/components/MemoryParentList/index.tsx
@@ -127,13 +127,13 @@ const MemoryParentItem = React.memo(({ memory, editing }: MemoryProps) => {
         </div>
         <div className="component-memory-parent-item">
           <MemoryParentContent memory={memory} editing={editing} />
-          <MemoryParentDragger editing={editing} toggleDraggable={toggleDraggable} />
           <button
             type="button"
             onClick={toggleChildrenVisible}
           >
             TOGGLE
           </button>
+          <MemoryParentDragger editing={editing} toggleDraggable={toggleDraggable} />
         </div>
       </div>
       <MemoryChildList

--- a/src/components/MemoryParentList/index.tsx
+++ b/src/components/MemoryParentList/index.tsx
@@ -79,17 +79,20 @@ const MemoryParentItem = React.memo(({ memory, editing }: MemoryProps) => {
   const onSelect = () => {
     const filteredItems = items.filter((it) => it.postId === currentPost.id);
 
+    const parent = memories.find((it) => it.id === memory.parentId);
+    const prefix = (!parent || parent.id === '0') ? '' : `${parent.content} > `;
+
     let newItem;
 
     if (filteredItems.length === 0) {
-      newItem = createInitialItemByMemory(currentPost.id, memory);
+      newItem = createInitialItemByMemory(currentPost.id, `${prefix}${memory.content}`, memory);
     } else {
       const sortedItems = filteredItems.length === 1
         ? filteredItems
         : filteredItems.sort((before, after) => key8Factory.compare(before.order, after.order));
       const lastItem = sortedItems[sortedItems.length - 1];
       const newOrder = key8Factory.build(lastItem.order, undefined);
-      newItem = createItemByMemory(newOrder, currentPost.id, memory.content, memory);
+      newItem = createItemByMemory(newOrder, currentPost.id, `${prefix}${memory.content}`, memory);
     }
 
     dispatch(addItem(newItem));
@@ -113,7 +116,7 @@ const MemoryParentItem = React.memo(({ memory, editing }: MemoryProps) => {
     <div style={outerStyle}>
       <div className="component-memory-parent-item-inner">
         <div className={`component-memory-parent-item-select ${selectable ? 'selectable' : 'non-selectable'}`}>
-          <div className="component-memory-parent-item-select-button" onClickCapture={onSelect} />
+          <div className="component-memory-parent-item-select-button" onClick={onSelect} />
         </div>
         <div className="component-memory-parent-item">
           <MemoryParentContent memory={memory} editing={editing} />

--- a/src/components/MemoryParentList/index.tsx
+++ b/src/components/MemoryParentList/index.tsx
@@ -113,6 +113,7 @@ const MemoryParentItem = React.memo(({ memory, editing }: MemoryProps) => {
   const outerStyle = {
     position: 'absolute',
     width: '100%',
+    backgroundColor: '#aaa',
     height,
   };
 

--- a/src/components/MemoryParentList/style.scss
+++ b/src/components/MemoryParentList/style.scss
@@ -14,6 +14,10 @@
     margin: 5px 0;
 }
 
+.component-memory-parent-item-outer-dragging {
+    z-index: 9999;
+}
+
 .children-visible {
     height: 200px;
 }

--- a/src/components/MemorySpareList/index.tsx
+++ b/src/components/MemorySpareList/index.tsx
@@ -3,10 +3,12 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Memory } from '../../types/object';
 import { RootState } from '../../redux/store';
 import './style.scss';
+import { key8Factory } from '../../redux/utils/keyFactory';
+import { updateMemory } from '../../redux/slices/memorySlice';
 
 export default React.memo(() => {
   const [currentMemories, setCurrentMemories] = useState([]);
@@ -30,9 +32,25 @@ const MemorySpareItem = React.memo(({ memory }: MemoryProps) => {
   const {
     memory: { memories },
   } = useSelector((state: RootState) => state);
+  const dispatch = useDispatch();
 
   const onFix = () => {
-    console.log('fix toggled.');
+    const fixedMemories = memories.filter((it) => it.fixed);
+
+    let order;
+
+    if (fixedMemories.length === 0) {
+      order = key8Factory.build();
+    } else {
+      const sortedMemories = fixedMemories.length === 1
+        ? fixedMemories
+        : fixedMemories.sort((before, after) => key8Factory.compare(before.order, after.order));
+      const lastMemory = sortedMemories[sortedMemories.length - 1];
+      order = key8Factory.build(lastMemory.order, undefined);
+    }
+
+    const newMemory = { ...memory, order, fixed: true };
+    dispatch(updateMemory({ id: memory.id, memory: newMemory }));
   };
 
   return (

--- a/src/components/MemorySpareList/index.tsx
+++ b/src/components/MemorySpareList/index.tsx
@@ -1,0 +1,53 @@
+import React, {
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useSelector } from 'react-redux';
+import { Memory } from '../../types/object';
+import { RootState } from '../../redux/store';
+import './style.scss';
+
+export default React.memo(() => {
+  const [currentMemories, setCurrentMemories] = useState([]);
+
+  const {
+    memory: { memories },
+  } = useSelector((state: RootState) => state);
+
+  useEffect(() => {
+    setCurrentMemories(memories.filter((it) => !it.fixed));
+  }, [memories]);
+
+  const children = useMemo(() => currentMemories.map((memory) => (
+    <MemorySpareItem key={memory.id} memory={memory} />
+  )), [currentMemories]);
+
+  return currentMemories.length > 0 ? <div>{children}</div> : <div />;
+});
+
+const MemorySpareItem = React.memo(({ memory }: MemoryProps) => {
+  const {
+    memory: { memories },
+  } = useSelector((state: RootState) => state);
+
+  const onFix = () => {
+    console.log('fix toggled.');
+  };
+
+  return (
+    <div className="component-memory-spare-item">
+      <div className="component-memory-spare-item-content">
+        <strong>{memory.content}</strong>
+      </div>
+      <button
+        type="button"
+        onClick={onFix}
+      >
+        FIX
+      </button>
+    </div>
+  );
+});
+
+type MemoryProps = { memory: Memory };

--- a/src/components/MemorySpareList/style.scss
+++ b/src/components/MemorySpareList/style.scss
@@ -1,0 +1,12 @@
+.component-memory-spare-item {
+    display: flex;
+    margin: 10px 0;
+    padding: 5px;
+    border: 5px solid #777;
+    background-color: #ddd;
+}
+
+.component-memory-spare-item-content {
+    color: #777;
+    flex: 1;
+}

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -12,12 +12,22 @@ import { createInitialItem, createItem } from '../../redux/utils/objectCreator';
 import { addItem } from '../../redux/slices/itemSlice';
 import { key8Factory } from '../../redux/utils/keyFactory';
 import useInput from '../../hooks/InputHook';
+import { setSelectable } from '../../redux/slices/memorySlice';
 
 export default React.memo(() => {
   const {
     post: { currentPost },
     item: { items },
   } = useSelector((state: RootState) => state);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (!currentPost) {
+      dispatch(setSelectable(false));
+    } else {
+      dispatch(setSelectable(true));
+    }
+  }, [currentPost]);
 
   return currentPost ? (
     <div className="component-post-wrapper">

--- a/src/components/SectionMemory/index.tsx
+++ b/src/components/SectionMemory/index.tsx
@@ -11,6 +11,7 @@ import { createMemory } from '../../redux/utils/objectCreator';
 import { key8Factory } from '../../redux/utils/keyFactory';
 import { Memory } from '../../types/object';
 import './style.scss';
+import MemorySpareList from '../MemorySpareList';
 
 export default React.memo(() => {
   const {
@@ -36,6 +37,8 @@ export default React.memo(() => {
       <HeaderMemory editing={editing} setEditing={setEditing} />
 
       <MemoryParentList editing={editing} />
+
+      <MemorySpareList />
     </div>
   ) : <div />;
 });

--- a/src/components/SectionMemory/index.tsx
+++ b/src/components/SectionMemory/index.tsx
@@ -1,15 +1,10 @@
 import React, {
-  Dispatch, FormEvent, SetStateAction, useEffect, useState,
+  Dispatch, SetStateAction, useEffect, useState,
 } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { RootState } from '../../redux/store';
 import MemoryParentList from '../MemoryParentList';
 import HeaderMemory from '../HeaderMemory';
-import useInput from '../../hooks/InputHook';
-import { addMemory } from '../../redux/slices/memorySlice';
-import { createMemory } from '../../redux/utils/objectCreator';
-import { key8Factory } from '../../redux/utils/keyFactory';
-import { Memory } from '../../types/object';
 import './style.scss';
 import MemorySpareList from '../MemorySpareList';
 
@@ -43,57 +38,7 @@ export default React.memo(() => {
   ) : <div />;
 });
 
-// todo : 별도의 모듈로 분리
-const NewMemoryForm = React.memo(({ memories, currentMemory }: NewMemoryFormPropTypes) => {
-  const dispatch = useDispatch();
-  const inputHooks = useInput('');
-
-  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (inputHooks.value.trim() !== '') {
-      const key = memories.length === 0
-        ? key8Factory.build()
-        : key8Factory.build(memories[memories.length - 1].order);
-      const newMemory = createMemory(
-        key,
-        inputHooks.value,
-        true,
-        currentMemory.id,
-        currentMemory.level + 1,
-      );
-      dispatch(addMemory(newMemory));
-    }
-    inputHooks.setValue('');
-  };
-
-  return (
-    <form
-      onSubmit={onSubmit}
-      className="component-memory-list-form"
-    >
-      <input
-        value={inputHooks.value}
-        onChange={inputHooks.onChangeValue}
-        placeholder="SAVE YOUR MEMORY."
-        className="component-memory-list-input"
-      />
-      <button
-        type="submit"
-        className="component-memory-list-submit"
-      >
-        ADD
-      </button>
-    </form>
-  );
-});
-
 export type EditingPropTypes = {
   editing: boolean,
   setEditing: Dispatch<SetStateAction<boolean>>,
-};
-
-type NewMemoryFormPropTypes = {
-  memories: Memory[],
-  currentMemory: Memory,
 };

--- a/src/components/SectionMemory/style.scss
+++ b/src/components/SectionMemory/style.scss
@@ -3,19 +3,3 @@
   padding: 10px;
   border: 5px solid #000;
 }
-
-.component-memory-list-form {
-  display: flex;
-}
-
-.component-memory-list-input {
-  flex: 1;
-  border: 5px solid #000;
-  padding: 5px;
-}
-
-.component-memory-list-submit {
-  width: 50px;
-  border: 5px solid #000;
-  margin-left: 5px;
-}

--- a/src/redux/api/mockingRepository.ts
+++ b/src/redux/api/mockingRepository.ts
@@ -29,13 +29,15 @@ let items = [
   createItem('K0000000', '5', 'fifth - 4', false),
 ];
 
+export const rootMemory = createRootMemory();
+
 let memories = [
-  createRootMemory(),
-  createMemory('A0000000', 'memory-1', true, '0', 1, '1'),
-  createMemory('B0000000', 'memory-2', true, '0', 1, '2'),
-  createMemory('C0000000', 'memory-3', true, '0', 1, '3'),
-  createMemory('D0000000', 'memory-4', true, '0', 1, '4'),
-  createMemory('E0000000', 'memory-5', true, '0', 1, '5'),
+  rootMemory,
+  createMemory('A0000000', 'memory-1', true, rootMemory.id, 1, '1'),
+  createMemory('B0000000', 'memory-2', true, rootMemory.id, 1, '2'),
+  createMemory('C0000000', 'memory-3', true, rootMemory.id, 1, '3'),
+  createMemory('D0000000', 'memory-4', true, rootMemory.id, 1, '4'),
+  createMemory('E0000000', 'memory-5', true, rootMemory.id, 1, '5'),
   createMemory('A0000000', 'child-memory-1', true, '1', 2),
   createMemory('B0000000', 'child-memory-2', true, '1', 2),
   createMemory('A0000000', 'child-memory-3', true, '2', 2),

--- a/src/redux/api/mockingRepository.ts
+++ b/src/redux/api/mockingRepository.ts
@@ -133,6 +133,12 @@ const mockingRepository = {
 
     resolve();
   }),
+  removeMemory: (memoryId: string): Promise<void> => new Promise((resolve) => {
+    memories = memories.filter((it) => it.id !== memoryId);
+    console.log('Memory removed!');
+
+    resolve();
+  }),
 };
 
 export default mockingRepository;

--- a/src/redux/slices/memorySlice.ts
+++ b/src/redux/slices/memorySlice.ts
@@ -21,7 +21,8 @@ export const initialState: InitialState = {
 
 const sleep = (n: number) => new Promise((resolve) => setTimeout(resolve, n));
 
-export const setSelectableAsync = createAsyncThunk(
+// 사용하진 않지만 thunk 예시로 남겨둔 코드
+const setSelectableAsync = createAsyncThunk(
   'memories/setSelectableAsync',
   async (to: boolean, { getState, dispatch }) => {
     if (to) {

--- a/src/redux/slices/memorySlice.ts
+++ b/src/redux/slices/memorySlice.ts
@@ -39,6 +39,22 @@ const setSelectableAsync = createAsyncThunk(
   },
 );
 
+// addMemory 이전에 fixed=false memory가 5개 이상일 경우 4개로 만들어주는 thunk 함수
+export const addMemoryThunk = createAsyncThunk(
+  'memories/addMemoryThunk',
+  async (memory: Memory, { getState, dispatch }) => {
+    const { memory: { memories } } = getState() as RootState;
+    let spareMemories = [...memories].filter((it) => !it.fixed);
+
+    while (spareMemories.length >= 5) {
+      dispatch(removeMemory(spareMemories[0].id));
+      spareMemories = spareMemories.slice(1);
+    }
+
+    dispatch(addMemory(memory));
+  },
+);
+
 export const getAllMemory = createAsyncThunk(
   'memories/getAllMemory',
   async () => repository.getAllMemory(),
@@ -66,6 +82,13 @@ export const memorySlice = createSlice({
 
       repository.addMemory(memory);
     },
+    removeMemory: (state: InitialState, action: PayloadAction<string>) => {
+      const memoryId = action.payload;
+
+      state.memories = state.memories.filter((it) => it.id !== memoryId);
+
+      repository.removeMemory(memoryId);
+    },
     setFocusedItem: (state: InitialState, action: PayloadAction<Item | undefined>) => {
       state.focusedItem = action.payload;
     },
@@ -91,7 +114,7 @@ export const memorySlice = createSlice({
 });
 
 export const {
-  updateMemory, addMemory, setSelectable, setFocusedItem,
+  updateMemory, addMemory, removeMemory, setSelectable, setFocusedItem,
 } = memorySlice.actions;
 
 export default memorySlice.reducer;

--- a/src/redux/utils/gridItemReplacer.js
+++ b/src/redux/utils/gridItemReplacer.js
@@ -1,5 +1,12 @@
 import { key8Factory } from './keyFactory';
 
+/**
+ * 인자로 받은 gridItem.getData()의 order를 새로운 order로 바꾸고, 바뀐 item을 반환하는 함수
+ * @param gridItem
+ * @param currentPosition
+ * @param gridList
+ * @returns {boolean|(*&{order: string})}
+ */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function replace(gridItem, currentPosition, gridList) {
   const item = gridItem.getData();
@@ -13,7 +20,7 @@ function replace(gridItem, currentPosition, gridList) {
 
   const margin = gridItem.getMargin();
   const height = gridItem.getHeight() + margin.top + margin.bottom;
-  const replacedIdx = position / height;
+  const replacedIdx = Math.floor(position / height);
 
   // target : item이 옮겨지는 위치에 원래 있었던 item
   const target = gridList[replacedIdx];

--- a/src/redux/utils/objectCreator.ts
+++ b/src/redux/utils/objectCreator.ts
@@ -84,6 +84,6 @@ export function createInitialItem(postId: string): Item {
   return createItem(key8Factory.build(), postId, '', false);
 }
 
-export function createInitialItemByMemory(postId: string, memory: Memory): Item {
-  return createItemByMemory(key8Factory.build(), postId, memory.content, memory);
+export function createInitialItemByMemory(postId: string, content: string, memory: Memory): Item {
+  return createItemByMemory(key8Factory.build(), postId, content, memory);
 }

--- a/src/redux/utils/objectCreator.ts
+++ b/src/redux/utils/objectCreator.ts
@@ -66,6 +66,20 @@ export function createMemory(
   };
 }
 
+export function createSpareMemory(content: string): Memory {
+  return {
+    id: nanoid(),
+    userId: 'tmp',
+    content,
+    order: '00000000',
+    fixed: false,
+    parentId: '0',
+    created: Date.now(),
+    updated: Date.now(),
+    level: 1,
+  };
+}
+
 export function createRootMemory(): Memory {
   return {
     id: '0',

--- a/src/redux/utils/objectCreator.ts
+++ b/src/redux/utils/objectCreator.ts
@@ -27,6 +27,24 @@ export function createItem(order: string, postId: string, content: string, done:
   };
 }
 
+export function createItemByMemory(
+  order: string,
+  postId: string,
+  content: string,
+  memory: Memory,
+): Item {
+  return {
+    id: nanoid(),
+    order,
+    postId,
+    content,
+    done: false,
+    memoryId: memory.id,
+    added: Date.now(),
+    updated: Date.now(),
+  };
+}
+
 export function createMemory(
   order: string,
   content: string,
@@ -64,4 +82,8 @@ export function createRootMemory(): Memory {
 
 export function createInitialItem(postId: string): Item {
   return createItem(key8Factory.build(), postId, '', false);
+}
+
+export function createInitialItemByMemory(postId: string, memory: Memory): Item {
+  return createItemByMemory(key8Factory.build(), postId, memory.content, memory);
 }


### PR DESCRIPTION
https://jngcii.notion.site/Requirements-Specification-9a74c53aa5394e20a737d26bc1c1fe84
위 명세서에 맞춰 memory 기능 완성시키기

[x] memory selectable 기능 개편 (onItemFocus -> onPostChosen)
[x] memory 선택 기능 작성
[x] child memory에 d&d 기능 추가
[x] memory 선택 시 category 보여주기
[x] item 직접 작성시, memory 추가
[x] memory fix 하는 기능 추가
[x] 새로운 memory 추가 기능 작성
[x] memory 삭제 및 수정 기능은 나중에!
[x] notion 요구사항 명세서 중, 아직 정책상 정해지지 않은 것 정하고 개발 진행
[x] 그 외 기능명세서에 적힌 것 중 진행되지 않은 부분 개발 진행

[ ] ~~child memory - parent memory - spare memory 간 d&d 기능 추가~~
> deprecated(spare -> parent 로 fix 후 edit 해서 위치 변경... 이게 더 깔끔할것같기도..! 그리고 내 서비스의 주력은 앱이다)